### PR TITLE
Don't send an empty array at the end of the stream

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,7 +41,9 @@ Chunker.prototype._transform = function(chunk, encoding, callback) {
 };
 
 Chunker.prototype._flush = function(callback) {
-  this.push(this.currentChunk);
+  if (this.currentChunk.length !== 0) {
+    this.push(this.currentChunk);
+  }
   callback();
 };
 


### PR DESCRIPTION
At flush time, don't push anything if the buffer is empty.